### PR TITLE
Added cache_path and cache_url system settings

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -30,6 +30,16 @@
             "type": "textfield",
             "area": "Sterc Extra",
             "value": ""
+        },{
+            "key": "cache_path",
+            "type": "textfield",
+            "area": "Cache Settings",
+            "value": ""
+        },{
+            "key": "cache_url",
+            "type": "textfield",
+            "area": "Cache Settings",
+            "value": ""
         }]
     }
     ,"database": {

--- a/core/components/modxminify/model/modxminify/modxminify.class.php
+++ b/core/components/modxminify/model/modxminify/modxminify.class.php
@@ -31,6 +31,11 @@ class modxMinify
         $assetsPath = $this->getOption('assets_path', $options, $this->modx->getOption('assets_path', null, MODX_ASSETS_PATH) . 'components/modxminify/');
         $assetsUrl = $this->getOption('assets_url', $options, $this->modx->getOption('assets_url', null, MODX_ASSETS_URL) . 'components/modxminify/');
 
+        $cachePath = $this->getOption('cache_path');
+        if (!$cachePath) $cachePath = $assetsPath.'cache';
+        $cacheUrl = $this->getOption('cache_url');
+        if (!$cacheUrl) $cacheUrl = $assetsUrl.'cache';
+
         /* loads some default paths for easier management */
         $this->options = array_merge(array(
             'namespace' => $this->namespace,
@@ -46,8 +51,8 @@ class modxMinify
             'connectorUrl' => $assetsUrl . 'connector.php',
             'rootPath' => $this->modx->getOption('base_path'),
             'cacheOptions' => array(xPDO::OPT_CACHE_KEY => 'modxminify'),
-            'cachePath' => $assetsPath.'cache',
-            'cacheUrl' => $assetsUrl.'cache'
+            'cachePath' => $cachePath,
+            'cacheUrl' => $cacheUrl
         ), $options);
 
         $this->modx->addPackage('modxminify', $this->getOption('modelPath'));


### PR DESCRIPTION
This PR adds the feature in issue #21.
There are two new system settings: cache_path and cache_url
This allows users to customise the location of the output.
If the system settings are empty (as they are by default), the locations will be the originals i.e. /assets/components/modxminify/cache/